### PR TITLE
fix login credentials exception

### DIFF
--- a/src/main/java/com/example/demo/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/example/demo/exception/ExceptionHandlerAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.validation.FieldError;
@@ -61,6 +62,17 @@ public class ExceptionHandlerAdvice {
             false,
             CustomStatusCode.UNAUTHORIZED,
             "Wrong Username or Password",
+            exc.getMessage()
+        );
+    }
+
+    @ExceptionHandler(InsufficientAuthenticationException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    CustomReturnData userLoginExc(InsufficientAuthenticationException exc) {
+        return new CustomReturnData(
+            false,
+            CustomStatusCode.UNAUTHORIZED,
+            "Missing login credentials",
             exc.getMessage()
         );
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,4 @@ spring:
 api:
   endpoint:
     base-url: /api/v1
+


### PR DESCRIPTION
### Дэплой:

приложение на хероку доступено теперь тут: [heroku](https://sb-lab-app-d5b0f7769d23.herokuapp.com/api/v1/subEntities)

### Стэйджинг
<img width="1276" alt="Screenshot 2024-10-30 at 18 32 27" src="https://github.com/user-attachments/assets/1aa9cc86-331d-478b-8c44-f02df01d9256">

вещь крутая но приходится отказаться (цена)

### фикс

теперь поддерживается InsufficientAuthenticationException
то есть при входе на ресурс, требующий аутентификацию:
<img width="682" alt="Screenshot 2024-10-30 at 18 28 35" src="https://github.com/user-attachments/assets/6b0cca5e-b64e-4284-987a-92b6a6ed1f5b">

и если пароль не вводить:
<img width="599" alt="Screenshot 2024-10-30 at 18 30 15" src="https://github.com/user-attachments/assets/f85ffad3-57cf-44e7-8feb-cd0bbadc5ade">
