### PR TITLE
feat: spring profiles and fix: 404 exc

### DIFF
--- a/src/main/java/com/example/demo/demoDBInitializer/DemoDBInitializer.java
+++ b/src/main/java/com/example/demo/demoDBInitializer/DemoDBInitializer.java
@@ -7,9 +7,11 @@ import com.example.demo.endpoints.sbUser.UserService;
 import com.example.demo.endpoints.subEntity.SubEntity;
 import com.example.demo.endpoints.subEntity.SubEntityRepository;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("development")
 public class DemoDBInitializer implements CommandLineRunner {
     private final SubEntityRepository subEntityRepository;
 

--- a/src/main/java/com/example/demo/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/example/demo/exception/ExceptionHandlerAdvice.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -106,6 +107,17 @@ public class ExceptionHandlerAdvice {
             false,
             CustomStatusCode.FORBIDDEN,
             "Access Denied. No permission",
+            exc.getMessage()
+        );
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    CustomReturnData notFoundExc(NoHandlerFoundException exc) {
+        return new CustomReturnData(
+            false,
+            CustomStatusCode.NOT_FOUND,
+            "Not Found",
             exc.getMessage()
         );
     }

--- a/src/main/resources/application-development.yml
+++ b/src/main/resources/application-development.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:sa
+    username: sa
+    password:
+#    driver-class-name: org.h2.Driver
+#  jpa:
+#    show-sql: true

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: # url of Postgres/MySQL ${datasource-url}
+    username: # Username of Postgres/MySQL ${datasource-username}
+    password: # Pass of postgres/MySQL ${datasource-password}
+  jpa:
+    hibernate:
+      ddl-auto: none # Data definition language auto generation

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,15 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:sa
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-#  jpa:
-#    show-sql: true
+  profiles:
+    active: development # ENV: SPRING_PROFILES_ACTIVE=production
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
 api:
   endpoint:
     base-url: /api/v1
 
+server:
+  port: 80

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,9 +1,12 @@
 package com.example.demo;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 // import org.springframework.boot.test.context.SpringBootTest;
 
 //@SpringBootTest
+
+@ActiveProfiles(value = "development")
 class DemoApplicationTests {
 
 	@Test

--- a/src/test/java/com/example/demo/endpoints/headObject/HeadObjectControllerIntegrationTest.java
+++ b/src/test/java/com/example/demo/endpoints/headObject/HeadObjectControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("HeadObject Integration API TESTS")
 @Tag("integration")
+@ActiveProfiles(value = "development")
 class HeadObjectControllerIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/example/demo/endpoints/headObject/HeadObjectControllerTest.java
+++ b/src/test/java/com/example/demo/endpoints/headObject/HeadObjectControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles(value = "development")
 class HeadObjectControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/demo/endpoints/headObject/HeadObjectServiceTest.java
+++ b/src/test/java/com/example/demo/endpoints/headObject/HeadObjectServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles(value = "development")
 class HeadObjectServiceTest {
 
     @Mock

--- a/src/test/java/com/example/demo/endpoints/sbUser/UserControllerIntegrationTest.java
+++ b/src/test/java/com/example/demo/endpoints/sbUser/UserControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @DisplayName("User Integration API TESTS")
+@ActiveProfiles(value = "development")
 class UserControllerIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/example/demo/endpoints/sbUser/UserControllerTest.java
+++ b/src/test/java/com/example/demo/endpoints/sbUser/UserControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles(value = "development")
 class UserControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/demo/endpoints/sbUser/UserServiceTest.java
+++ b/src/test/java/com/example/demo/endpoints/sbUser/UserServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
@@ -24,6 +25,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles(value = "development")
 class UserServiceTest {
     @Mock
     UserRepository userRepository;

--- a/src/test/java/com/example/demo/endpoints/subEntity/SubEntityControllerIntegrationTest.java
+++ b/src/test/java/com/example/demo/endpoints/subEntity/SubEntityControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("SubEntity Integration API TESTS")
 @Tag("integration")
+@ActiveProfiles(value = "development")
 class SubEntityControllerIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/example/demo/endpoints/subEntity/SubEntityControllerTest.java
+++ b/src/test/java/com/example/demo/endpoints/subEntity/SubEntityControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false) // security switch off
+@ActiveProfiles(value = "development")
 class SubEntityControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/demo/endpoints/subEntity/SubEntityServiceTest.java
+++ b/src/test/java/com/example/demo/endpoints/subEntity/SubEntityServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles(value = "development")
 class SubEntityServiceTest {
 
     @Mock


### PR DESCRIPTION
# фича:
спринг профили локально - development (H2 и dbInitializer), при деплое - production (postgrees, mysql... - удалённо настроенная база)
<img width="635" alt="Screenshot 2024-10-31 at 21 23 41" src="https://github.com/user-attachments/assets/cf852f22-6977-4c28-94bd-6846ae1013dd">


# fix:
при входе на несуществующий адрес было:
<img width="435" alt="Screenshot 2024-10-31 at 21 21 46" src="https://github.com/user-attachments/assets/1e65325b-1411-4494-95b2-24720fce3364">
стало:
<img width="429" alt="Screenshot 2024-10-31 at 21 20 47" src="https://github.com/user-attachments/assets/a197e8d4-b068-410a-b33a-0a52492ab443">
